### PR TITLE
Use license file if set

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -5,6 +5,15 @@ echo "-----> Installing PrinceXML $PRINCE_VERSION"
 [ -d .downloads ] || mkdir .downloads
 (cd .downloads; [ -d "prince-$PRINCE_VERSION-linux-amd64-static" ] ||
   curl -s http://www.princexml.com/download/prince-$PRINCE_VERSION-linux-generic-x86_64.tar.gz | tar xzf -)
+
+LICENSE_FILE=$3/PRINCEXML_LICENSE
+if [ -f $LICENSE_FILE ]; then
+	echo "       Configuring license file"
+	cp $LICENSE_FILE ./.downloads/prince-$PRINCE_VERSION-linux-generic-x86_64/lib/prince/license/license.dat
+else
+	echo "       No license found"
+fi
+
 echo $1 | ./.downloads/prince-$PRINCE_VERSION-linux-generic-x86_64/install.sh
 cat >$1/bin/prince <<EOF
 #!/bin/sh


### PR DESCRIPTION
Environment variables are [available to the buildpack as files](https://devcenter.heroku.com/articles/buildpack-api#bin-compile).

If the `PRINCEXML_LICENSE` environment variable has been set it is coped to `lib/prince/license/license.dat` within the extracted contents of the Prince archive before the installer is run.

I haven't access to an actual license but it does seem to behave as intended:

```
$ heroku config:get PRINCEXML_LICENSE
steve
$ heroku run bash
Running bash on prince-xml-demo... up, run.8861
~ $  cat /app/lib/prince/license/license.dat
steve~ $ 
```
